### PR TITLE
feat: WebSocket 연결용 임시 토큰 발급 엔드포인트 추가

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -55,4 +55,17 @@ export class AuthService {
     const { token, expiresAt } = await this.createUserAndToken(defaultUserData);
     return { token, expiresAt };
   }
+
+  generateWebSocketToken(userId: string): { token: string; expiresAt: number } {
+    const payload = {
+      userId,
+      type: 'websocket',
+      iat: Math.floor(Date.now() / 1000),
+    };
+
+    const token = jwt.sign(payload, this.jwtSecret, { expiresIn: '10m' });
+    const expiresAt = Date.now() + (10 * 60 * 1000); // 10분
+
+    return { token, expiresAt };
+  }
 }


### PR DESCRIPTION
## 주요 변경사항
- 🔐 **실제 사용자 생성**: 임시 사용자 대신 실제 사용자 생성 및 저장
- 🍪 **쿠키 기반 인증**: JWT 토큰을 httpOnly 쿠키로 안전하게 저장
- 👤 **사용자 관리**: 생성, 수정, 삭제 완전한 CRUD 기능
- 📍 **위치 기반 매칭**: 근처 사용자 검색 기능
- 🛡️ **WebSocket 보안**: 일회용 토큰으로 WebSocket 연결 보안 강화

---

## API Endpoints

### 인증
- `POST /auth/start` - 세션 시작 및 사용자 생성
- `GET /auth/websocket-token` - WebSocket용 임시 토큰 발급 (10분)
- `POST /auth/token/:userId` - 기존 사용자 토큰 재발급

### 사용자 관리
- `GET /users/:id` - 사용자 정보 조회
- `PATCH /users/:id` - 사용자 정보 업데이트
- `DELETE /users/:id` - 사용자 삭제/탈퇴
- `GET /users/nearby` - 근처 사용자 검색

---

## 보안 개선
- **REST API**: httpOnly 쿠키 (XSS 방지)
- **WebSocket**: 쿠키 인증 후 일회용 토큰 (10분 유효)
- **토큰 관리**: 일반 토큰 3일, WebSocket 토큰 10분